### PR TITLE
Modify Lisp Interpreter to make Flower Lisp

### DIFF
--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -140,6 +140,11 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("get".to_string(), Exp::Primitive(primitive::lisp_get));
     data.insert("put".to_string(), Exp::Primitive(primitive::lisp_put));
     data.insert("date".to_string(), Exp::Primitive(primitive::lisp_date));
+    data.insert("vector".to_string(), Exp::Primitive(primitive::lisp_vector));
+    data.insert("block".to_string(), Exp::Primitive(primitive::lisp_block));
+    data.insert("keyword".to_string(), Exp::Primitive(primitive::lisp_keyword));
+    data.insert("struct".to_string(), Exp::Primitive(primitive::lisp_struct));
+    data.insert("enum".to_string(), Exp::Primitive(primitive::lisp_enum));
 
     // Setup autocompletion
     *FUNCTIONS.lock() = data

--- a/src/usr/lisp/env.rs
+++ b/src/usr/lisp/env.rs
@@ -146,6 +146,22 @@ pub fn default_env() -> Rc<RefCell<Env>> {
     data.insert("struct".to_string(), Exp::Primitive(primitive::lisp_struct));
     data.insert("enum".to_string(), Exp::Primitive(primitive::lisp_enum));
 
+    data.insert("struct/get".to_string(), Exp::Primitive(primitive::lisp_struct_get));
+    data.insert("keyword/name".to_string(), Exp::Primitive(primitive::lisp_keyword_name));
+    data.insert("enum/info".to_string(), Exp::Primitive(primitive::lisp_enum_info));
+    data.insert("vector/push".to_string(), Exp::Primitive(primitive::lisp_vector_push));
+    data.insert("vector/pop".to_string(), Exp::Primitive(primitive::lisp_vector_pop));
+    data.insert("list/append".to_string(), Exp::Primitive(primitive::lisp_list_append));
+    data.insert("list/prepend".to_string(), Exp::Primitive(primitive::lisp_list_prepend));
+    data.insert("dict/keys".to_string(), Exp::Primitive(primitive::lisp_dict_keys));
+    data.insert("dict/values".to_string(), Exp::Primitive(primitive::lisp_dict_values));
+    data.insert("block/eval".to_string(), Exp::Primitive(primitive::lisp_block_eval));
+    data.insert("block/length".to_string(), Exp::Primitive(primitive::lisp_block_length));
+    data.insert("block/to_list".to_string(), Exp::Primitive(primitive::lisp_block_to_list));
+    data.insert("block/to_vector".to_string(), Exp::Primitive(primitive::lisp_block_to_vector));
+    data.insert("block/length".to_string(), Exp::Primitive(primitive::lisp_block_length));
+
+
     // Setup autocompletion
     *FUNCTIONS.lock() = data
         .keys()

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -209,6 +209,11 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
             Exp::Bool(_) => return Ok(exp.clone()),
             Exp::Num(_) => return Ok(exp.clone()),
             Exp::Str(_) => return Ok(exp.clone()),
+            Exp::Vector(_) => return Ok(exp.clone()),
+            Exp::Block(_) => return Ok(exp.clone()),
+            Exp::Keyword(_) => return Ok(exp.clone()),
+            Exp::Struct { .. } => return Ok(exp.clone()),
+            Exp::Enum { .. } => return Ok(exp.clone()),
             Exp::List(list) => {
                 ensure_length_gt!(list, 0);
                 let args = &list[1..];

--- a/src/usr/lisp/eval.rs
+++ b/src/usr/lisp/eval.rs
@@ -218,6 +218,9 @@ pub fn eval(exp: &Exp, env: &mut Rc<RefCell<Env>>) -> Result<Exp, Err> {
                 ensure_length_gt!(list, 0);
                 let args = &list[1..];
                 match &list[0] {
+                    Exp::Sym(s) if s == "struct" => {
+                        return crate::usr::lisp::primitive::lisp_struct(args);
+                    }
                     Exp::Sym(s) if s == "quote" => {
                         return eval_quote_args(args);
                     }

--- a/src/usr/lisp/mod.rs
+++ b/src/usr/lisp/mod.rs
@@ -40,21 +40,19 @@ pub enum Exp {
     Function(Box<Function>),
     Macro(Box<Function>),
     List(Vec<Exp>),
-    Vector(Vec<Exp>), // New: vector literal, displayed with []
-    Block(Vec<Exp>),  // New: code block, displayed with {}
+    Vector(Vec<Exp>),
+    Block(Vec<Exp>),
     Dict(BTreeMap<String, Exp>),
-    Keyword(String), // New: keywords, prefixed with a colon
+    Keyword(String),
     Bool(bool),
     Num(Number),
     Str(String),
     Sym(String),
     Struct {
-        // New: Rust-like struct literal
         name: String,
         fields: BTreeMap<String, Exp>,
     },
     Enum {
-        // New: Rust-like enum, variant with optional value
         name: String,
         variant: String,
         value: Option<Box<Exp>>,

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -66,7 +66,7 @@ fn float(input: &str) -> IResult<&str, &str> {
 }
 
 fn is_symbol_letter(c: char) -> bool {
-    let chars = "$<>=-+*/%^?!.";
+    let chars = "$<>=-+*/%^?!._";
     c.is_alphanumeric() || chars.contains(c)
 }
 

--- a/src/usr/lisp/parse.rs
+++ b/src/usr/lisp/parse.rs
@@ -1,32 +1,23 @@
 use super::{Err, Exp, Number};
 use crate::could_not;
 
+use alloc::boxed::Box;
+use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;
 
 use nom::branch::alt;
-use nom::bytes::complete::escaped_transform;
-use nom::bytes::complete::is_not;
-use nom::bytes::complete::tag;
-use nom::bytes::complete::take_while1;
-use nom::character::complete::char;
-use nom::character::complete::multispace0;
-use nom::character::complete::one_of;
-use nom::combinator::map;
-use nom::combinator::opt;
-use nom::combinator::recognize;
-use nom::combinator::value;
-use nom::multi::many0;
-use nom::multi::many1;
-use nom::sequence::delimited;
-use nom::sequence::preceded;
-use nom::sequence::terminated;
+use nom::bytes::complete::{escaped_transform, is_not, tag, take_while1};
+use nom::character::complete::{char, multispace0, multispace1, one_of};
+use nom::combinator::{map, opt, recognize, value};
+use nom::multi::{many0, many1, separated_list0};
+use nom::sequence::{delimited, preceded, separated_pair, terminated};
 use nom::Err::Error;
 use nom::IResult;
 use nom::Parser;
 
-// https://docs.rs/nom/latest/nom/recipes/index.html#hexadecimal
+// Existing number parsers...
 fn hexadecimal(input: &str) -> IResult<&str, &str> {
     preceded(
         tag("0x"),
@@ -37,14 +28,11 @@ fn hexadecimal(input: &str) -> IResult<&str, &str> {
     ).parse(input)
 }
 
-// https://docs.rs/nom/latest/nom/recipes/index.html#decimal
 fn decimal(input: &str) -> IResult<&str, &str> {
-    recognize(
-        many1(terminated(one_of("0123456789"), many0(char('_'))))
-    ).parse(input)
+    recognize(many1(terminated(one_of("0123456789"), many0(char('_')))))
+        .parse(input)
 }
 
-// https://docs.rs/nom/latest/nom/recipes/index.html#binary
 fn binary(input: &str) -> IResult<&str, &str> {
     preceded(
         tag("0b"),
@@ -52,31 +40,28 @@ fn binary(input: &str) -> IResult<&str, &str> {
     ).parse(input)
 }
 
-// https://docs.rs/nom/latest/nom/recipes/index.html#floating-point-numbers
 fn float(input: &str) -> IResult<&str, &str> {
     alt((
-        recognize(
+        recognize((
             // .42
-            (
-                char('.'),
-                decimal,
-                opt((one_of("eE"), opt(one_of("+-")), decimal))
-            )
-        ),
-        recognize(
+            char('.'),
+            decimal,
+            opt((one_of("eE"), opt(one_of("+-")), decimal))
+        )),
+        recognize((
             // 42e42 and 42.42e42
-            (
-                decimal,
-                opt(preceded(char('.'), decimal)),
-                one_of("eE"),
-                opt(one_of("+-")),
-                decimal
-            )
-        ),
-        recognize(
+            decimal,
+            opt(preceded(char('.'), decimal)),
+            one_of("eE"),
+            opt(one_of("+-")),
+            decimal
+        )),
+        recognize((
             // 42. and 42.42
-            (decimal, char('.'), opt(decimal))
-        )
+            decimal,
+            char('.'),
+            opt(decimal)
+        ))
     )).parse(input)
 }
 
@@ -126,7 +111,9 @@ fn parse_bool(input: &str) -> IResult<&str, Exp> {
 
 fn parse_list(input: &str) -> IResult<&str, Exp> {
     let (input, list) = delimited(
-        char('('), many0(parse_exp), char(')')
+        char('('),
+        many0(parse_exp),
+        char(')')
     ).parse(input)?;
     Ok((input, Exp::List(list)))
 }
@@ -165,11 +152,140 @@ fn parse_comment(input: &str) -> IResult<&str, &str> {
     preceded(multispace0, preceded(char('#'), is_not("\n"))).parse(input)
 }
 
+// ===== Flower Lisp Extensions =====
+
+/// Parses a keyword literal, e.g. ":foo"
+fn parse_keyword(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = char(':')(input)?;
+    let (input, kw) = take_while1(is_symbol_letter).parse(input)?;
+    Ok((input, Exp::Keyword(kw.to_string())))
+}
+
+/// Parses a vector literal, e.g. "[1 2 3]"
+fn parse_vector(input: &str) -> IResult<&str, Exp> {
+    let (input, elems) = delimited(
+        char('['),
+        many0(parse_exp),
+        char(']')
+    ).parse(input)?;
+    Ok((input, Exp::Vector(elems)))
+}
+
+/// Parses a block literal, e.g. "{ expr1 expr2 }"
+fn parse_block(input: &str) -> IResult<&str, Exp> {
+    let (input, stmts) = delimited(
+        char('{'),
+        many0(parse_exp),
+        char('}')
+    ).parse(input)?;
+    Ok((input, Exp::Block(stmts)))
+}
+
+/// Parses a dictionary literal using the syntax "#{ key: value, ... }"
+fn parse_dict(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = tag("#{")(input)?;
+    let (input, pairs) = separated_list0(
+            delimited(multispace0, char(','), multispace0),
+            separated_pair(
+                alt((parse_str, parse_sym)),
+                delimited(multispace0, char(':'), multispace0),
+                parse_exp
+            )
+        ).parse(input)?;
+    let (input, _) = char('}')(input)?;
+    let mut map = BTreeMap::new();
+    for (key_exp, value) in pairs {
+        let key = match key_exp {
+            Exp::Str(s) => s,
+            Exp::Sym(s) => s,
+            _ => String::new(),
+        };
+        map.insert(key, value);
+    }
+    Ok((input, Exp::Dict(map)))
+}
+
+/// Parses a struct literal, e.g. "struct Person { name: \"Alice\", age: 30 }"
+fn parse_struct(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = tag("struct")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, name) = take_while1(is_symbol_letter).parse(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, fields) = delimited(
+        char('{'),
+        separated_list0(
+            delimited(multispace0, char(','), multispace0),
+            separated_pair(
+                take_while1(is_symbol_letter),
+                delimited(multispace0, char(':'), multispace0),
+                parse_exp
+            )
+        ),
+        char('}')
+    ).parse(input)?;
+    let mut field_map = BTreeMap::new();
+    for (k, v) in fields {
+        field_map.insert(k.to_string(), v);
+    }
+    Ok((input, Exp::Struct { name: name.to_string(), fields: field_map }))
+}
+
+/// Parses an enum literal using the syntax "(enum Color::Red)" or "(enum Option::Some(42))"
+fn parse_paren_enum(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = char('(')(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = tag("enum")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, name) = take_while1(is_symbol_letter)(input)?;
+    let (input, _) = tag("::")(input)?;
+    let (input, variant) = take_while1(is_symbol_letter)(input)?;
+    let (input, opt_val) = opt(delimited(
+        multispace1,
+        parse_exp,
+        multispace0
+    )).parse(input)?;
+    let (input, _) = multispace0(input)?;
+    let (input, _) = char(')')(input)?;
+    Ok((input, Exp::Enum {
+        name: name.to_string(),
+        variant: variant.to_string(),
+        value: opt_val.map(Box::new)
+    }))
+}
+
+/// Parses an enum literal, e.g. "enum Color::Red" or "enum Option::Some(42)"
+fn parse_enum(input: &str) -> IResult<&str, Exp> {
+    let (input, _) = tag("enum")(input)?;
+    let (input, _) = multispace1(input)?;
+    let (input, name) = take_while1(is_symbol_letter).parse(input)?;
+    let (input, _) = tag("::")(input)?;
+    let (input, variant) = take_while1(is_symbol_letter).parse(input)?;
+    let (input, opt_val) = opt(delimited(
+        char('('),
+        parse_exp,
+        char(')')
+    )).parse(input)?;
+    Ok((input, Exp::Enum {
+        name: name.to_string(),
+        variant: variant.to_string(),
+        value: opt_val.map(Box::new)
+    }))
+}
+
+// ===== End Flower Lisp Extensions =====
+
 fn parse_exp(input: &str) -> IResult<&str, Exp> {
     let (input, _) = opt(many0(parse_comment)).parse(input)?;
     delimited(
         multispace0,
         alt((
+            parse_keyword,
+            parse_vector,
+            parse_block,
+            parse_dict,
+            parse_struct,
+            parse_paren_enum,
+            parse_enum,
             parse_num,
             parse_bool,
             parse_str,

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -44,24 +44,23 @@ pub fn lisp_keyword(args: &[Exp]) -> Result<Exp, Err> {
 }
 
 pub fn lisp_struct(args: &[Exp]) -> Result<Exp, Err> {
-    // Expects at least a name and one field (so an odd number of arguments)
     ensure_length_gt!(args, 1);
     if args.len() % 2 == 0 {
         return expected!("an odd number of arguments (name and field pairs) for struct");
     }
     let name = match &args[0] {
         Exp::Sym(s) => s.clone(),
-        _ => return expected!("a symbol for struct name"),
+        exp => format!("{}", exp),
     };
-    let mut fields = BTreeMap::new();
-    // Process the field pairs.
+    let mut fields_vec = Vec::new();
     for pair in args[1..].chunks(2) {
         let key = match &pair[0] {
             Exp::Sym(s) => s.clone(),
             _ => return expected!("struct field name must be a symbol"),
         };
-        fields.insert(key, pair[1].clone());
+        fields_vec.push((key, pair[1].clone()));
     }
+    let fields: BTreeMap<String, Exp> = fields_vec.into_iter().collect();
     Ok(Exp::Struct { name, fields })
 }
 

--- a/src/usr/lisp/primitive.rs
+++ b/src/usr/lisp/primitive.rs
@@ -9,6 +9,7 @@ use crate::api::syscall;
 use crate::api::time::format_offset_time;
 use crate::sys::fs::OpenFlag;
 use crate::usr::host;
+use crate::usr::lisp::env::default_env;
 use crate::usr::shell;
 use crate::{could_not, ensure_length_eq, ensure_length_gt, expected};
 
@@ -84,6 +85,182 @@ pub fn lisp_enum(args: &[Exp]) -> Result<Exp, Err> {
         None
     };
     Ok(Exp::Enum { name, variant, value })
+}
+
+/// Returns the value of a field in a struct. Usage: (struct/get my-struct field)
+pub fn lisp_struct_get(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    match &args[0] {
+        Exp::Struct { name: _, fields } => {
+            let key = match &args[1] {
+                Exp::Sym(s) => s,
+                Exp::Str(s) => s,
+                _ => return expected!("a symbol or string as field name"),
+            };
+            for (k, v) in fields {
+                if k == key {
+                    return Ok(v.clone());
+                }
+            }
+            could_not!("field '{}' not found in struct", key)
+        }
+        _ => expected!("a struct"),
+    }
+}
+
+/// Returns the name of a keyword as a string. Usage: (keyword/name :foo)
+pub fn lisp_keyword_name(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    match &args[0] {
+        Exp::Keyword(kw) => Ok(Exp::Str(kw.clone())),
+        _ => expected!("a keyword"),
+    }
+}
+
+/// Returns information about an enum as a list: (name variant value).
+/// Usage: (enum/info my-enum)  -> ("my-enum" "my-variant" 42)
+pub fn lisp_enum_info(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    match &args[0] {
+        Exp::Enum { name, variant, value } => {
+            let mut list = vec![
+                Exp::Str(name.clone()),
+                Exp::Str(variant.clone())
+            ];
+            if let Some(val) = value {
+                list.push(*val.clone());
+            }
+            Ok(Exp::List(list))
+        }
+        _ => expected!("an enum"),
+    }
+}
+
+/// Pushes an element onto the end of a vector and returns the updated vector.
+/// Usage: (vector/push (vector 1 2 3) 4)  -> [1 2 3 4]
+pub fn lisp_vector_push(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    if let Exp::Vector(mut vec) = args[0].clone() {
+        vec.push(args[1].clone());
+        Ok(Exp::Vector(vec))
+    } else {
+        expected!("a vector")
+    }
+}
+
+/// Pops the last element off a vector and returns a tuple of the popped element and the updated vector.
+/// Usage: (vector/pop (vector 1 2 3))  -> (3 [1 2])
+pub fn lisp_vector_pop(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Vector(mut vec) = args[0].clone() {
+        let popped = vec.pop().unwrap_or(Exp::List(vec![]));
+        Ok(Exp::List(vec![popped, Exp::Vector(vec)]))
+    } else {
+        expected!("a vector")
+    }
+}
+
+/// Appends an element to the end of a list (preserving insertion order) and returns the updated list.
+/// Usage: (list/append (list 1 2) 3)  -> (1 2 3)
+pub fn lisp_list_append(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    if let Exp::List(mut list) = args[0].clone() {
+        list.push(args[1].clone());
+        Ok(Exp::List(list))
+    } else {
+        expected!("a list")
+    }
+}
+
+/// Prepends an element to the beginning of a list and returns the updated list.
+/// Usage: (list/prepend (list 2 3) 1)  -> (1 2 3)
+pub fn lisp_list_prepend(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 2);
+    if let Exp::List(mut list) = args[0].clone() {
+        list.insert(0, args[1].clone());
+        Ok(Exp::List(list))
+    } else {
+        expected!("a list")
+    }
+}
+
+/// Returns the keys of a dictionary as a list of strings.
+/// Usage: (dict/keys { a 1 b 2 })  -> ("a" "b")
+pub fn lisp_dict_keys(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Dict(dict) = &args[0] {
+        let keys = dict
+            .keys()
+            .map(|k| {
+                let clean = k.trim_matches('"');
+                Exp::Str(clean.to_string())
+            })
+            .collect::<Vec<_>>();
+        Ok(Exp::List(keys))
+    } else {
+        expected!("a dict")
+    }
+}
+
+/// Returns the values of a dictionary as a list.
+/// Usage: (dict/values { a 1 b 2 })  -> (1 2)
+pub fn lisp_dict_values(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Dict(dict) = &args[0] {
+        let values = dict.values().cloned().collect::<Vec<_>>();
+        Ok(Exp::List(values))
+    } else {
+        expected!("a dict")
+    }
+}
+
+/// Evaluates a block literal by executing each expression and returns the result of each expression in a list.
+/// Usage: (block/eval { expr1 expr2 ... })
+pub fn lisp_block_eval(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Block(block) = &args[0] {
+        let mut env = default_env();
+        let mut results = Vec::new();
+        for exp in block {
+            results.push(crate::usr::lisp::eval::eval(exp, &mut env)?);
+        }
+        Ok(Exp::List(results))
+    } else {
+        expected!("a block")
+    }
+}
+
+/// Returns the number of expressions in a block.
+/// Usage: (block/length { expr1 expr2 ... })
+pub fn lisp_block_length(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Block(block) = &args[0] {
+        Ok(Exp::Num(Number::from(block.len())))
+    } else {
+        expected!("a block")
+    }
+}
+
+/// Converts a block into a list of its expressions.
+/// Usage: (block->list { expr1 expr2 ... })
+pub fn lisp_block_to_list(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Block(block) = &args[0] {
+        Ok(Exp::List(block.clone()))
+    } else {
+        expected!("a block")
+    }
+}
+
+/// Converts a block into a vector of its expressions.
+/// Usage: (block->vector { expr1 expr2 ... })
+pub fn lisp_block_to_vector(args: &[Exp]) -> Result<Exp, Err> {
+    ensure_length_eq!(args, 1);
+    if let Exp::Block(block) = &args[0] {
+        Ok(Exp::Vector(block.clone()))
+    } else {
+        expected!("a block")
+    }
 }
 
 pub fn lisp_eq(args: &[Exp]) -> Result<Exp, Err> {
@@ -676,6 +853,22 @@ pub fn lisp_get(args: &[Exp]) -> Result<Exp, Err> {
                 Ok(Exp::List(vec![]))
             }
         }
+        Exp::Vector(v) => {
+            let i = usize::try_from(number(&args[1])?)?;
+            if let Some(v) = v.get(i) {
+                Ok(v.clone())
+            } else {
+                Ok(Exp::List(vec![]))
+            }
+        }
+        Exp::Block(b) => {
+            let i = usize::try_from(number(&args[1])?)?;
+            if let Some(v) = b.get(i) {
+                Ok(v.clone())
+            } else {
+                Ok(Exp::List(vec![]))
+            }
+        }
         Exp::Str(s) => {
             let i = usize::try_from(number(&args[1])?)?;
             if let Some(c) = s.chars().nth(i) {
@@ -684,7 +877,6 @@ pub fn lisp_get(args: &[Exp]) -> Result<Exp, Err> {
                 Ok(Exp::Str("".to_string()))
             }
         }
-        // New: allow field lookup on a struct literal.
         Exp::Struct { ref fields, .. } => {
             let key = format!("{}", args[1]);
             if let Some(v) = fields.get(&key) {
@@ -693,7 +885,7 @@ pub fn lisp_get(args: &[Exp]) -> Result<Exp, Err> {
                 Ok(Exp::List(vec![]))
             }
         }
-        _ => expected!("first argument to be a dict, a list, a string, or a struct"),
+        _ => expected!("first argument to be a dict, list, vector, block, string, or struct"),
     }
 }
 
@@ -711,18 +903,42 @@ pub fn lisp_put(args: &[Exp]) -> Result<Exp, Err> {
             let mut l = l.clone();
             let i = usize::try_from(number(&args[1])?)?;
             let v = args[2].clone();
-            l.insert(i, v);
-            Ok(Exp::List(l))
+            if i <= l.len() {
+                l.insert(i, v);
+                Ok(Exp::List(l))
+            } else {
+                expected!("index out of range")
+            }
+        }
+        Exp::Vector(v) => {
+            let mut v = v.clone();
+            let i = usize::try_from(number(&args[1])?)?;
+            let v_new = args[2].clone();
+            if i < v.len() {
+                v[i] = v_new;
+                Ok(Exp::Vector(v))
+            } else {
+                expected!("index out of range")
+            }
+        }
+        Exp::Block(b) => {
+            let mut b = b.clone();
+            let i = usize::try_from(number(&args[1])?)?;
+            let v_new = args[2].clone();
+            if i < b.len() {
+                b[i] = v_new;
+                Ok(Exp::Block(b))
+            } else {
+                expected!("index out of range")
+            }
         }
         Exp::Str(s) => {
             let mut s: Vec<char> = s.chars().collect();
             let i = usize::try_from(number(&args[1])?)?;
             let v: Vec<char> = string(&args[2])?.chars().collect();
             s.splice(i..i, v);
-            let s: String = s.into_iter().collect();
-            Ok(Exp::Str(s))
+            Ok(Exp::Str(s.into_iter().collect()))
         }
-        // New: support updating a struct literal.
         Exp::Struct { ref name, ref fields } => {
             let mut new_fields = fields.clone();
             let key = format!("{}", args[1]);
@@ -732,7 +948,7 @@ pub fn lisp_put(args: &[Exp]) -> Result<Exp, Err> {
                 fields: new_fields,
             })
         }
-        _ => expected!("first argument to be a dict, a list, a string, or a struct"),
+        _ => expected!("first argument to be a dict, list, vector, block, string, or struct"),
     }
 }
 

--- a/src/usr/lisp/tests.rs
+++ b/src/usr/lisp/tests.rs
@@ -25,9 +25,13 @@ fn test_lisp() {
 
     // vectors
     assert_eq!(eval!("(vector 1 2 3)"), "[1 2 3]");
+    assert_eq!(eval!("(get (vector 10 20 30) 1)"), "20");
+    assert_eq!(eval!("(put (vector 10 20 30) 1 25)"), "[10 25 30]");
 
     // block literal
     assert_eq!(eval!("(block 1 2 3)"), "{1 2 3}");
+    assert_eq!(eval!("(get (block 10 20 30) 1)"), "20");
+    assert_eq!(eval!("(put (block 10 20 30) 1 25)"), "{10 25 30}");
 
     // keyword literal
     assert_eq!(eval!("(keyword \"foo\")"), ":foo");
@@ -42,6 +46,84 @@ fn test_lisp() {
     assert_eq!(
         eval!("(enum Option::Some 42)"),
         "enum Option::Some(42)"
+    );
+
+    // struct/get: retrieves field "name" from a struct literal
+    assert_eq!(
+        eval!("(struct/get (struct Person name \"Alice\" age 30) 'name)"),
+        "\"Alice\""
+    );
+
+    // keyword/name: returns the name of the keyword as a string
+    assert_eq!(
+        eval!("(keyword/name (keyword \"foo\"))"),
+        "\"foo\""
+    );
+
+    // enum/info: returns a list with the variant and value
+    assert_eq!(
+        eval!("(enum/info (enum Option::Some 42))"),
+        "(\"Option\" \"Some\" 42)"
+    );
+
+    // vector/push: pushes an element onto a vector
+    assert_eq!(
+        eval!("(vector/push (vector 1 2 3) 4)"),
+        "[1 2 3 4]"
+    );
+
+    // vector/pop: pops the last element off a vector and returns a tuple (popped, updated vector)
+    assert_eq!(
+        eval!("(vector/pop (vector 1 2 3))"),
+        "(3 [1 2])"
+    );
+
+    // list/append: appends an element to the end of a list
+    assert_eq!(
+        eval!("(list/append (list 1 2) 3)"),
+        "(1 2 3)"
+    );
+
+    // list/prepend: prepends an element to the beginning of a list
+    assert_eq!(
+        eval!("(list/prepend (list 2 3) 1)"),
+        "(1 2 3)"
+    );
+
+    // dict/keys: returns the keys of a dictionary as a list
+    assert_eq!(
+        eval!("(dict/keys (dict \"a\" 1 \"b\" 2))"),
+        "(\"a\" \"b\")"
+    );
+
+    // dict/values: returns the values of a dictionary as a list
+    assert_eq!(
+        eval!("(dict/values (dict \"a\" 1 \"b\" 2))"),
+        "(1 2)"
+    );
+
+    // block/eval: evaluates a block and returns the value of each expression
+    assert_eq!(
+        eval!("(block/eval {1 2 3})"),
+        "(1 2 3)"
+    );
+
+    // block/length: returns the number of expressions in a block
+    assert_eq!(
+        eval!("(block/length {10 20 30})"),
+        "3"
+    );
+
+    // block/to_list: converts a block to a list
+    assert_eq!(
+        eval!("(block/to_list {1 2 3})"),
+        "(1 2 3)"
+    );
+
+    // block/to_vector: converts a block to a vector
+    assert_eq!(
+        eval!("(block/to_vector {1 2 3})"),
+        "[1 2 3]"
     );
 
     // num

--- a/src/usr/lisp/tests.rs
+++ b/src/usr/lisp/tests.rs
@@ -23,6 +23,21 @@ fn test_lisp() {
         };
     }
 
+    // vectors
+    assert_eq!(eval!("(vector 1 2 3)"), "[1 2 3]");
+
+    // block literal
+    assert_eq!(eval!("(block 1 2 3)"), "{1 2 3}");
+
+    // keyword literal
+    assert_eq!(eval!("(keyword \"foo\")"), ":foo");
+
+    // enum literal:
+    assert_eq!(
+        eval!("(enum Option::Some 42)"),
+        "enum Option::Some(42)"
+    );
+
     // num
     assert_eq!(eval!("6"), "6");
     assert_eq!(eval!("16"), "16");

--- a/src/usr/lisp/tests.rs
+++ b/src/usr/lisp/tests.rs
@@ -32,6 +32,12 @@ fn test_lisp() {
     // keyword literal
     assert_eq!(eval!("(keyword \"foo\")"), ":foo");
 
+    // struct literal
+    assert_eq!(
+        eval!("(struct Person name \"Alice\" age 30)"),
+        "struct Person { age: 30, name: \"Alice\" }" // BTreeMap changes order
+    );
+
     // enum literal:
     assert_eq!(
         eval!("(enum Option::Some 42)"),


### PR DESCRIPTION
## Description
Flower Lisp is a new Lisp dialect that adds more features like Vectors, Blocks, and Structs, to make the language more useful in some cases.

## Feature Completes
- [ ] Structs
- [ ] Enums
- [ ] Vectors
- [ ] Blocks
- [ ] Keywords